### PR TITLE
Add step to push to staging bucket

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,5 +26,5 @@ jobs:
         shell: bash
         run: "aws s3 sync site-root s3://staging.andrewstahlman.com"
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.website_publisher_access_key }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.website_publisher_secret_key }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.staging_website_publisher_access_key }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.staging_website_publisher_secret_key }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,8 @@ jobs:
         with:
           name: site-root
       - name: Push to staging bucket
-        env:
-          AWS_ACCESS_KEY_ID: {{ secrets.website_publisher_access_key }}
-          AWS_SECRET_ACCESS_KEY: {{ secrets.website_publisher_secret_key }}
         shell: bash
-        run: aws s3 sync site-root s3://staging.andrewstahlman.com
+        run: "aws s3 sync site-root s3://staging.andrewstahlman.com"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.website_publisher_access_key }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.website_publisher_secret_key }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,5 +26,5 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: {{ secrets.website_publisher_access_key }}
           AWS_SECRET_ACCESS_KEY: {{ secrets.website_publisher_secret_key }}
-          shell: bash
-          run: aws s3 sync site-root s3://staging.andrewstahlman.com
+        shell: bash
+        run: aws s3 sync site-root s3://staging.andrewstahlman.com

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on: [push]
 
 jobs:
   build:
+    name: Build the site
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -13,3 +14,17 @@ jobs:
         with:
           name: site-root
           path: build
+  push-to-staging:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download .zip
+        uses: actions/download-artifact@v1
+        with:
+          name: site-root
+      - name: Push to staging bucket
+        env:
+          AWS_ACCESS_KEY_ID: {{ secrets.website_publisher_access_key }}
+          AWS_SECRET_ACCESS_KEY: {{ secrets.website_publisher_secret_key }}
+          shell: bash
+          run: aws s3 sync site-root s3://staging.andrewstahlman.com


### PR DESCRIPTION
Push the build artifacts to `s3://staging.andrewstahlman.com`

Promotion to the prod S3 bucket is still done locally via the `publish` script.